### PR TITLE
[sdk] Fix memory error in getScanDataWithIntervalHq.

### DIFF
--- a/sdk/sdk/include/rplidar_driver.h
+++ b/sdk/sdk/include/rplidar_driver.h
@@ -301,13 +301,16 @@ public:
     /// The interface will return RESULT_OPERATION_TIMEOUT to indicate that not even a single node can be retrieved since last call. 
     DEPRECATED(virtual u_result getScanDataWithInterval(rplidar_response_measurement_node_t * nodebuffer, size_t & count)) = 0;
 
-    /// Return received scan points even if it's not complete scan
+    /// Return received scan points even if it's not complete scan.
     ///
-    /// \param nodebuffer     Buffer provided by the caller application to store the scan data
+    /// \param nodebuffer     Buffer provided by the caller application to store the scan data. This buffer must be initialized by
+    ///                       the caller.
     ///
-    /// \param count          Once the interface returns, this parameter will store the actual received data count.
+    /// \param count          The caller must initialize this parameter to set the max data count of the provided buffer (in unit of rplidar_response_measurement_node_t).
+    ///                       Once the interface returns, this parameter will store the actual received data count.
     ///
-    /// The interface will return RESULT_OPERATION_TIMEOUT to indicate that not even a single node can be retrieved since last call. 
+    /// The interface will return RESULT_OPERATION_TIMEOUT to indicate that not even a single node can be retrieved since last call.
+    /// The interface will return RESULT_REMAINING_DATA to indicate that the given buffer is full, but that there remains data to be read.
     virtual u_result getScanDataWithIntervalHq(rplidar_response_measurement_node_hq_t * nodebuffer, size_t & count) = 0;
 
     virtual ~RPlidarDriver() {}

--- a/sdk/sdk/src/hal/types.h
+++ b/sdk/sdk/src/hal/types.h
@@ -88,6 +88,7 @@ typedef uint32_t u_result;
 #define RESULT_OK                       0
 #define RESULT_FAIL_BIT                 0x80000000
 #define RESULT_ALREADY_DONE             0x20
+#define RESULT_REMAINING_DATA           0x21
 #define RESULT_INVALID_DATA             (0x8000 | RESULT_FAIL_BIT)
 #define RESULT_OPERATION_FAIL           (0x8001 | RESULT_FAIL_BIT)
 #define RESULT_OPERATION_TIMEOUT        (0x8002 | RESULT_FAIL_BIT)


### PR DESCRIPTION
Fix https://github.com/Slamtec/rplidar_sdk/issues/9

```getScanDataWithIntervalHq``` now limits the amount of data to return to the input buffer size, warning the user with a return code if there is remaining data to read.