### PR TITLE
[apps][fix] Make examples compilable in Visual Studios 2017 and 2019

### DIFF
--- a/sdk/app/frame_grabber/stdafx.h
+++ b/sdk/app/frame_grabber/stdafx.h
@@ -76,3 +76,4 @@ using namespace WTL;
 //STL
 #include <vector>
 #include <map>
+#include <string>

--- a/sdk/app/simple_grabber/main.cpp
+++ b/sdk/app/simple_grabber/main.cpp
@@ -54,7 +54,7 @@ using namespace rp::standalone::rplidar;
 void print_usage(int argc, const char * argv[])
 {
     printf("Simple LIDAR data grabber for RPLIDAR.\n"
-           "Version: "RPLIDAR_SDK_VERSION"\n"
+           "Version: " RPLIDAR_SDK_VERSION "\n"
            "Usage:\n"
            "%s <com port> [baudrate]\n"
            "The default baudrate is 115200(for A2) or 256000(for A3). Please refer to the datasheet for details.\n"
@@ -189,7 +189,7 @@ int main(int argc, const char * argv[]) {
         }
 
         printf("\n"
-                "Version: "RPLIDAR_SDK_VERSION"\n"
+                "Version: " RPLIDAR_SDK_VERSION "\n"
                 "Firmware Ver: %d.%02d\n"
                 "Hardware Rev: %d\n"
                 , devinfo.firmware_version>>8

--- a/sdk/app/ultra_simple/main.cpp
+++ b/sdk/app/ultra_simple/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, const char * argv[]) {
     bool useArgcBaudrate = false;
 
     printf("Ultra simple LIDAR data grabber for RPLIDAR.\n"
-           "Version: "RPLIDAR_SDK_VERSION"\n");
+           "Version: " RPLIDAR_SDK_VERSION "\n");
 
     // read serial port from the command line...
     if (argc>1) opt_com_path = argv[1]; // or set to a fixed value: e.g. "com3" 

--- a/sdk/workspaces/vc10/frame_grabber/frame_grabber.vcxproj
+++ b/sdk/workspaces/vc10/frame_grabber/frame_grabber.vcxproj
@@ -53,7 +53,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\app\frame_grabber\ref\wtl;..\..\..\sdk\src;..\..\..\sdk\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\app\frame_grabber\ref\wtl;..\..\..\sdk\src;..\..\..\sdk\include;.;..\..\..\app\frame_grabber;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <Link>


### PR DESCRIPTION
Changes are tiny:
* `app\frame_grabber` added to includes path
* `RPLIDAR_SDK_VERSION` macro now separated from quotes with spaces, so compiler don't confuse it with string literals
* `#include <string>` added to `stdafx.h` in `frame_grabber`