### PR TITLE
Fix missing return in function not returning void

### DIFF
--- a/sdk/sdk/src/rplidar_driver.cpp
+++ b/sdk/sdk/src/rplidar_driver.cpp
@@ -2219,7 +2219,7 @@ u_result RPlidarDriverImplCommon::startMotor()
         }
     }
     else {
-        setLidarSpinSpeed(600);//set default rpm to tof lidar
+        return setLidarSpinSpeed(600);//set default rpm to tof lidar
     }
 
 }


### PR DESCRIPTION
This fixes a build error: 

```
error: control reaches end of non-void function [-Werror=return-type]
```