### PR TITLE
Fixup serial comms and unused code

### DIFF
--- a/sdk/sdk/src/arch/linux/net_socket.cpp
+++ b/sdk/sdk/src/arch/linux/net_socket.cpp
@@ -435,7 +435,7 @@ public:
     virtual u_result send(const void * buffer, size_t len) 
     {
         size_t ans = ::send( _socket_fd, buffer, len, MSG_NOSIGNAL);
-        if (ans == (int)len) {
+        if (ans == len) {
             return RESULT_OK;
         } else {
             switch (errno) {

--- a/sdk/sdk/src/arch/macOS/net_serial.cpp
+++ b/sdk/sdk/src/arch/macOS/net_serial.cpp
@@ -221,6 +221,7 @@ int raw_serial::waitfordata(_word_size_t data_count, _u32 timeout, _word_size_t 
         }
     }
 
+    uint lastReturnedSize = 0;
     while ( isOpened() )
     {
         /* Do the select */
@@ -249,6 +250,12 @@ int raw_serial::waitfordata(_word_size_t data_count, _u32 timeout, _word_size_t 
             }
             else
             {
+                if (lastReturnedSize == *returned_size) {
+                    // don't want a tight loop, return what we've got
+                    // note: requires caller handle incomplete wait (not a timeout)
+                    return 0;
+                }
+                lastReturnedSize = *returned_size;
                 int remain_timeout = timeout_val.tv_sec*1000000 + timeout_val.tv_usec;
                 int expect_remain_time = (data_count - *returned_size)*1000000*8/_baudrate;
                 if (remain_timeout > expect_remain_time)

--- a/sdk/sdk/src/hal/types.h
+++ b/sdk/sdk/src/hal/types.h
@@ -103,8 +103,7 @@ typedef uint32_t u_result;
 #define IS_OK(x)    ( ((x) & RESULT_FAIL_BIT) == 0 )
 #define IS_FAIL(x)  ( ((x) & RESULT_FAIL_BIT) )
 
-
-typedef _word_size_t (THREAD_PROC * thread_proc_t ) ( void * );
+typedef _word_size_t ( * thread_proc_t ) ( void * );
 
 
 #if defined (_BUILD_AS_DLL)

--- a/sdk/sdk/src/rplidar_driver_impl.h
+++ b/sdk/sdk/src/rplidar_driver_impl.h
@@ -92,7 +92,6 @@ protected:
     virtual u_result _waitNode(rplidar_response_measurement_node_t * node, _u32 timeout = DEFAULT_TIMEOUT);
     virtual u_result  _cacheCapsuledScanData();
     virtual u_result _waitCapsuledNode(rplidar_response_capsule_measurement_nodes_t & node, _u32 timeout = DEFAULT_TIMEOUT);
-    virtual int _getSyncBitByAngle(const int current_angle_q16, const int angleInc_q16);
     virtual void     _capsuleToNormal(const rplidar_response_capsule_measurement_nodes_t & capsule, rplidar_response_measurement_node_hq_t *nodebuffer, size_t &nodeCount);
     virtual void     _dense_capsuleToNormal(const rplidar_response_capsule_measurement_nodes_t & capsule, rplidar_response_measurement_node_hq_t *nodebuffer, size_t &nodeCount);
     
@@ -118,7 +117,6 @@ protected:
     _u16                    _cached_sampleduration_std;
     _u16                    _cached_sampleduration_express;
     _u8                     _cached_express_flag;
-    float                   _cached_current_us_per_sample;
 
     rplidar_response_capsule_measurement_nodes_t _cached_previous_capsuledata;
     rplidar_response_dense_capsule_measurement_nodes_t _cached_previous_dense_capsuledata;
@@ -126,7 +124,6 @@ protected:
     rplidar_response_hq_capsule_measurement_nodes_t _cached_previous_Hqdata;
     bool                                         _is_previous_capsuledataRdy;
     bool                                         _is_previous_HqdataRdy;
-    bool                                         _syncBit_is_finded;
 
 	
 


### PR DESCRIPTION
The important fix here is in serial where a tight loop can happen if no data is being sent but the FD can still be read. This has it return earlier to allow for proper reading of the buffer. After reading the buffer, the `select` happens again and will timeout properly. Doesn't appear to be an issue in windows.