### PR TITLE
Fix compiling wiwh gcc >= 11 on linux

### DIFF
--- a/sdk/src/arch/linux/net_socket.cpp
+++ b/sdk/src/arch/linux/net_socket.cpp
@@ -167,7 +167,7 @@ u_result SocketAddress::getAddressAsString(char * buffer, size_t buffersize) con
 
         break;
     }
-    return ans<=0?RESULT_OPERATION_FAIL:RESULT_OK;
+    return ans==NULL?RESULT_OPERATION_FAIL:RESULT_OK;
 }
 
 


### PR DESCRIPTION
As Core Issue 1512 has been implemented in gcc 11 (see [here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87699)), it is no longer possible to do ordered comparison between pointers and zero.

This fix changes the ordered comparison into an equality with NULL, allowing gcc 11 to compile the sdk.

Tested with gcc 11.1