### PR TITLE
Error fixing

### DIFF
--- a/sdk/src/sl_lidar_driver.cpp
+++ b/sdk/src/sl_lidar_driver.cpp
@@ -553,10 +553,10 @@ namespace sl {
         {
             switch (_dataEvt.wait(timeout))
             {
-            case rp::hal::Event::EVENT_TIMEOUT:
+            case (unsigned long int)rp::hal::Event::EVENT_TIMEOUT:
                 count = 0;
                 return SL_RESULT_OPERATION_TIMEOUT;
-            case rp::hal::Event::EVENT_OK:
+            case (unsigned long int)rp::hal::Event::EVENT_OK:
             {
                 if (_cached_scan_node_hq_count == 0) return SL_RESULT_OPERATION_TIMEOUT; //consider as timeout
 


### PR DESCRIPTION
Fixing - narrowing conversion of «rp::hal::Event::EVENT_TIMEOUT» from «int» to «long unsigned int»