### PR TITLE
fix(net_socket): compare ans with NULL to check failed inet_ntop() call

### DIFF
--- a/sdk/src/arch/linux/net_socket.cpp
+++ b/sdk/src/arch/linux/net_socket.cpp
@@ -167,7 +167,7 @@ u_result SocketAddress::getAddressAsString(char * buffer, size_t buffersize) con
 
         break;
     }
-    return ans<=0?RESULT_OPERATION_FAIL:RESULT_OK;
+    return ans==NULL?RESULT_OPERATION_FAIL:RESULT_OK;
 }
 
 


### PR DESCRIPTION
In getAddressAsString(), we are comparing ans <=  0 to check for failure. When compiling with g++ 11.2 (Ubuntu 22.02), this gave the following error:

src/arch/linux/net_socket.cpp:170:15: error: ordered comparison of pointer with integer zero (‘const char*’ and ‘int’)

inet_ntop returns a NULL pointer for failure and non-NULL otherwise. So in order to fix this, we can simply compare ans with NULL.