### PR TITLE
Fix arg typo in ultra dense capsule to normal method

### DIFF
--- a/sdk/include/sl_lidar_driver_impl.h
+++ b/sdk/include/sl_lidar_driver_impl.h
@@ -115,7 +115,7 @@ namespace sl {
 			void _dense_capsuleToNormal(const sl_lidar_response_capsule_measurement_nodes_t & capsule, sl_lidar_response_measurement_node_hq_t *nodebuffer, size_t &nodeCount);
 			sl_result _cacheCapsuledScanData();
 
-			void _ultra_dense_capsuleToNormal(const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t& capslue, sl_lidar_response_measurement_node_hq_t* nodebuffer, size_t& nodeCount);
+			void _ultra_dense_capsuleToNormal(const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t& capsule, sl_lidar_response_measurement_node_hq_t* nodebuffer, size_t& nodeCount);
 			sl_result _waitUltraDenseCapsuledNode(sl_lidar_response_ultra_dense_capsule_measurement_nodes_t& node, sl_u32 timeout = DEFAULT_TIMEOUT);
 			sl_result _cacheUltraDenseCapsuledScanData();
 			

--- a/sdk/src/sl_lidar_driver.cpp
+++ b/sdk/src/sl_lidar_driver.cpp
@@ -1777,7 +1777,7 @@ namespace sl {
             return SL_RESULT_OPERATION_TIMEOUT;
         }
 
-        void _ultra_dense_capsuleToNormal(const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t& capslue, sl_lidar_response_measurement_node_hq_t* nodebuffer, size_t& nodeCount)
+        void _ultra_dense_capsuleToNormal(const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t& capsule, sl_lidar_response_measurement_node_hq_t* nodebuffer, size_t& nodeCount)
         {
             static int lastNodeSyncBit = 0;
             const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t* ultra_dense_capsule = reinterpret_cast<const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t*>(&capslue);

--- a/sdk/src/sl_lidar_driver.cpp
+++ b/sdk/src/sl_lidar_driver.cpp
@@ -1780,7 +1780,7 @@ namespace sl {
         void _ultra_dense_capsuleToNormal(const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t& capsule, sl_lidar_response_measurement_node_hq_t* nodebuffer, size_t& nodeCount)
         {
             static int lastNodeSyncBit = 0;
-            const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t* ultra_dense_capsule = reinterpret_cast<const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t*>(&capslue);
+            const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t* ultra_dense_capsule = reinterpret_cast<const sl_lidar_response_ultra_dense_capsule_measurement_nodes_t*>(&capsule);
             nodeCount = 0;
             if (_is_previous_capsuledataRdy) {
                 int diffAngle_q8;


### PR DESCRIPTION
The initial capsule argument had a typo and was written as `capslue`. While it was consistently named across the definition and declaration, as well as inside the method, it made searching for capsules more difficult. Typos may also not be obvious to non-native English speakers.