### PR TITLE
sl_async_transceiver.cpp: fixed return value in case of opening error

### DIFF
--- a/sdk/src/sl_async_transceiver.cpp
+++ b/sdk/src/sl_async_transceiver.cpp
@@ -201,8 +201,6 @@ u_result AsyncTransceiver::openChannelAndBind(IChannel* channel)
 		rp::hal::AutoLocker l(_opLocker);
 
         // try to open the channel ...
-        Result<nullptr_t> ans = SL_RESULT_OK;
-
         if (!channel->open()) {
             ans= RESULT_OPERATION_FAIL;
             break;


### PR DESCRIPTION
If the opening was unsuccessful, it returned OK.